### PR TITLE
Add truncate to IBM recipe

### DIFF
--- a/documentation/cookbook/llm-open-connector-ibm.md
+++ b/documentation/cookbook/llm-open-connector-ibm.md
@@ -7,7 +7,9 @@ date: 2024-10-18
 
 # LLM Open Connector + watsonx
 
-Learn how to implement Salesforce's [LLM Open Connector](/docs/apis/llm-open-connector/) with the IBM watsonx platform. 
+Learn how to implement Salesforce's [LLM Open Connector](/docs/apis/llm-open-connector/) with the IBM watsonx platform.
+
+<!-- truncate -->
 
 ## Prerequisites
 


### PR DESCRIPTION
Add the truncate directive to the IBM cookbook post so that it doesn't display the whole recipe on the Cookbook page.